### PR TITLE
Subdivide when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 The Python package `drugdemand` is an experimental modeling framework for developing hypothetical, forward-looking projections of demand for childhood immunizations. Currently, this approach is deterministic, data-informed calculation. In other words, the modeling framework produces models with no stochastic or dynamical elements. Once a model has been formulated, the model parameters can be adjusted to produce demand estimates for hypothetical scenarios.
 
-The modeling framework centers around _populations_ of children. Each population has a size (i.e., number of children) and one or other more _attributes_ that uniquely determine the volume and timing of demand for an immunization among that population. A model consists of these populations and a _demand function_ that takes a population as input, examines its size and attributes, and determines if the population would have demand for an immunization, and if so, when and how much.
+The modeling framework centers around _populations_ of children. Populations are defined by _characteristics_ and their _levels_. For example, the characteristic "sex" might have levels "male" and "female." Each population also has a size (i.e., number of children). A population's characteristics and size uniquely determine the volume and timing of demand for an immunization among that population. A model consists of these populations and a _demand function_. This function takes a population's characteristics and size as inputs, then determines if the population would have demand for an immunization, and if so, when and how much.
 
-The code consists of these classes:
+Currently, the model assumes that each level of each characteristic has some frequency in the population, and that characteristics are statistically independent. For example, if half of children are each sex, and half are in each of a low and high risk, then one-quarter will be male and low risk.
 
-- `Population` is a data class contains a population's size (i.e., number of people) and attributes (e.g., birth date, will uptake).
-- `IndependentSubpopulations` is a data manager that subdivides a list of `Population`s into smaller populations based on lists of attributes.
-- `DrugDosage`, `DrugQuantity`, and `DrugDemand` are data classes that account for dosages (e.g., 50mg vs. 100mg), numbers of doses, and times of demand.
+The model is designed to begin with a single, monolithic population that is partitioned only when necessary in order to compute demand. If the demand function represents some kind of decision tree, then the starting population will be partitioned at each node in the tree.
+
+The most important elements in the code are:
+
+- `PopulationManager` is a class that keeps track of populations, their characteristics, and their sizes.
+- `CharacteristicProportions` is a way of articulating how characteristics are distributed in the population.
+- The `PopulationManger.map()` method allows a demand function to be iterated over all populations, including partitioning according to `CharacteristicProportions`.
 
 ## Example application to nirsevimab
 

--- a/drugdemand/__init__.py
+++ b/drugdemand/__init__.py
@@ -21,7 +21,7 @@ class DrugDosage:
 
 @dataclass
 class DrugQuantity:
-    """Quantity of a drug-dosage"""
+    """Quantity of a drug-dosage (e.g., 3 doses of nirsevimab 50mg)"""
 
     drug_dosage: DrugDosage
     n_doses: int
@@ -36,7 +36,8 @@ class DrugQuantity:
 
 @dataclass
 class DrugDemand:
-    """Quantity of a drug-dosage, at a time"""
+    """Quantity of a drug-dosage, at a time (e.g., 3 doses of nirsevimab 50mg
+    on 2024-10-01)"""
 
     drug_dosage: DrugDosage
     n_doses: int
@@ -79,6 +80,8 @@ class UnresolvedCharacteristic:
 
 
 class UnresolvedCharacteristicException(Exception):
+    """Raised when an unresolved characteristic is queried"""
+
     pass
 
 
@@ -97,16 +100,28 @@ class PopulationID(Mapping):
 
     @classmethod
     def from_characteristics(cls, chars: [str]):
+        """Create a PopulationID with unresolved characteristics
+
+        Args:
+            chars (str]): List of characteristics
+
+        Returns:
+            PopulationID: PopulationID with unresolved characteristics
+        """
         return cls({char: UnresolvedCharacteristic() for char in chars})
 
     @staticmethod
     def _validate_mapping(x: dict) -> None:
-        assert all(isinstance(k, str) for k in x.keys())
+        """Ensure all characteristics are strings"""
+        assert all(isinstance(char, str) for char in x.keys())
 
     def is_resolved(self, char: str) -> bool:
+        """Is the characteristic resolved?"""
         return not isinstance(self.mapping[char], UnresolvedCharacteristic)
 
     def __getitem__(self, char: str):
+        """Get the level of a characteristic, raising an exception if
+        the characteristic is unresolved and raise_if_unresolved flag is True"""
         if self.raise_if_unresolved and not self.is_resolved(char):
             raise UnresolvedCharacteristicException(char)
         else:

--- a/drugdemand/__init__.py
+++ b/drugdemand/__init__.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Callable
 from collections.abc import Iterator
 import numpy as np
-
-Pop = dict[str, Any]
+from collections.abc import Mapping
 
 
 @dataclass
@@ -51,16 +50,98 @@ class CharacteristicProportions(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.validate()
+        self.validate(self)
 
-    def validate(self):
+    @staticmethod
+    def validate(x):
         # all keys (characteristics) should be strings
-        assert all(isinstance(k, str) for k in self.keys())
+        assert all(isinstance(k, str) for k in x.keys())
         # all values (proportions) should be dictionaries
-        assert all(isinstance(v, dict) for v in self.values())
+        assert all(isinstance(v, dict) for v in x.values())
         # all proportions of a characteristic should sum to 1
-        for char, props in self.items():
+        for char, props in x.items():
             assert np.isclose(sum(props.values()), 1.0)
+
+
+class UnresolvedCharacteristic:
+    """Marker for a population characteristic not yet resolved"""
+
+    def __eq__(self, other):
+        """All UnresolvedCharacteristics are equal, for ease of testing"""
+        return isinstance(other, UnresolvedCharacteristic)
+
+    def __hash__(self):
+        """Identical hash, so it can go into dictionaries"""
+        return hash("UnresolvedCharacteristic")
+
+    def __str__(self):
+        return "unresolved"
+
+
+class UnresolvedCharacteristicException(Exception):
+    pass
+
+
+class PopulationID(Mapping):
+    """Immutable, dictionary-like class to represent a population ID. The keys
+    are strings (characteristics) and the values are anything (levels).
+
+    If an UnresolvedCharacteristic would be returned, instead raise an
+    exception, to be caught by PopulationManager.map().
+    """
+
+    def __init__(self, data=(), raise_if_unresolved: bool = False):
+        self.mapping = dict(data)
+        self.raise_if_unresolved = raise_if_unresolved
+        self._validate_mapping(self.mapping)
+
+    @classmethod
+    def from_characteristics(cls, chars: [str]):
+        return cls({char: UnresolvedCharacteristic() for char in chars})
+
+    @staticmethod
+    def _validate_mapping(x: dict) -> None:
+        assert all(isinstance(k, str) for k in x.keys())
+
+    def is_resolved(self, char: str) -> bool:
+        return not isinstance(self.mapping[char], UnresolvedCharacteristic)
+
+    def __getitem__(self, char: str):
+        if self.raise_if_unresolved and not self.is_resolved(char):
+            raise UnresolvedCharacteristicException(char)
+        else:
+            return self.mapping[char]
+
+    def __len__(self):
+        return len(self.mapping)
+
+    def __iter__(self):
+        return iter(self.mapping)
+
+    def __str__(self):
+        return str(self.mapping)
+
+    def __repr__(self):
+        return f"PopulationID({self.mapping!r})"
+
+    def __or__(self, other: dict):
+        return PopulationID(self.mapping | other)
+
+
+class RaiseIfUnresolvedManager:
+    """With-statement manager that sets a PopulationID to raise if an
+    unresolved characteristic is queried, and then resets to *not* raise
+    when exiting the with-statement"""
+
+    def __init__(self, pop: PopulationID):
+        self.pop = pop
+
+    def __enter__(self) -> None:
+        self.pop.raise_if_unresolved = True
+
+    def __exit__(self, exc_type, value, tb) -> bool:
+        self.pop.raise_if_unresolved = False
+        return False
 
 
 class PopulationManager:
@@ -72,58 +153,60 @@ class PopulationManager:
 
         # set up the data, with an initial population with no characteristics
         self.data = {}
-        self.set_size({}, size)
+        self.set_size(PopulationID({}), size)
 
-    def get_size(self, pop: Pop) -> float:
+    def get_size(self, pop: PopulationID) -> float:
         return self.data[self._pop_to_tuple(pop)]
 
-    def set_size(self, pop: Pop, value: float) -> None:
+    def set_size(self, pop: PopulationID, value: float) -> None:
         self.data[self._pop_to_tuple(pop)] = value
 
-    def delete_pop(self, pop: Pop) -> None:
+    def delete_pop(self, pop: PopulationID) -> None:
         del self.data[self._pop_to_tuple(pop)]
 
-    def pops(self) -> Iterator[Pop]:
+    def pops(self) -> Iterator[PopulationID]:
         return map(self._tuple_to_pop, self.data.keys())
 
-    def _tuple_to_pop(self, levels: tuple[str, ...]) -> Pop:
-        return dict(zip(self.chars, levels))
+    def _tuple_to_pop(self, levels: tuple[str, ...]) -> PopulationID:
+        return PopulationID(zip(self.chars, levels))
 
-    def _pop_to_tuple(self, pop: Pop) -> tuple[str, ...]:
-        return tuple(pop.get(char, None) for char in self.chars)
+    def _pop_to_tuple(self, pop: PopulationID) -> tuple[str, ...]:
+        return tuple(pop.get(char, UnresolvedCharacteristic()) for char in self.chars)
 
     def map(
-        self, f: Callable[[Pop, float], dict[str, Any]]
-    ) -> Iterator[tuple[Pop, Any]]:
+        self, f: Callable[[PopulationID, float], Any], *args, **kwargs
+    ) -> Iterator[tuple[PopulationID, Any]]:
         """Map a function over all subpopulations
 
         Args:
-            f (Callable[dict[str, Any], dict[str, Any]]): The function to be mapped. It
-              should take a dictionary `{characteristic: level}` and the population
-              size and return a
-              dictionary `{"characteristic": characteristic, "value": value}`. If
-              `characteristic` is None, it means the function could successfully
-              interpret the `{characteristic: level}` dictionary. If not, it should
-              be the key of the characteristic that caused the failure and that
-              the population needs to be partitioned on.
+            f (Callable[[PopulationID, float], Any]): The function to be mapped. It
+              should take a PopulationID and the population size. If the function
+              references a key in the PopulationID that has not been resolved, that
+              characteristic will be partitioned and resolved.
+            args, kwargs: further arguments passed to `f`
 
         Yields:
             Iterator: 2-tuples of the population (defined by its `{characteristic: level}`
-              dictionary) and the output of the `f` function for that population
+              dictionary) and the output of `f` for that population
         """
         pop_stack = list(self.pops())
 
         while pop_stack:
             pop = pop_stack.pop()
-            result = f(pop, self.get_size(pop))
-            assert set(result.keys()) == {"characteristic", "value"}
-            if result["characteristic"] is None:
-                yield pop, result["value"]
-            else:
-                new_pops = self.partition(pop, result["characteristic"])
+
+            # get the size (need to do this *before* allowing exception raising)
+            size = self.get_size(pop)
+
+            try:
+                with RaiseIfUnresolvedManager(pop):
+                    value = f(pop, size, *args, **kwargs)
+                    yield pop, value
+            except UnresolvedCharacteristicException as e:
+                char_to_resolve = e.args[0]
+                new_pops = self.partition(pop, char_to_resolve)
                 pop_stack = new_pops + pop_stack
 
-    def partition(self, pop: Pop, char: str) -> [Pop]:
+    def partition(self, pop: PopulationID, char: str) -> [PopulationID]:
         """Partition a population on a characteristic
 
         Args:
@@ -134,7 +217,7 @@ class PopulationManager:
             list: A list of new population IDs
         """
         # the characteristic we are partitioning on should not have a level
-        assert pop[char] is None
+        assert not pop.is_resolved(char)
 
         parent_size = self.get_size(pop)
 
@@ -147,21 +230,3 @@ class PopulationManager:
 
         self.delete_pop(pop)
         return new_pops
-
-    @staticmethod
-    def update_tuple(x: tuple, i: int, new_val: Any) -> tuple:
-        """Given a tuple, return a new tuple with one value replaced
-
-        Args:
-            x (tuple): input tuple
-            i (int): index of the value to replace
-            new_val (Any): value to insert
-
-        Returns:
-            tuple: tuple of same length, with new value
-        """
-        assert 0 <= i < len(x)
-        out = tuple(x[:i]) + (new_val,) + tuple(x[i + 1 :])
-        assert len(out) == len(x)
-        assert out[i] == new_val
-        return out

--- a/drugdemand/nirsevimab.py
+++ b/drugdemand/nirsevimab.py
@@ -77,7 +77,9 @@ class NirsevimabCalculator:
             raise NotImplementedError()
 
     @classmethod
-    def calculate_demand(cls, pop: Population, pars: dict) -> DrugDemand | None:
+    def calculate_demand(
+        cls, pop: dict[str, str], size: float, pars: dict
+    ) -> DrugDemand | None:
         """Calculate amount and timing of demand, for a single population
 
         see https://downloads.aap.org/AAP/PDF/Nirsevemab-Visual-Guide.pdf

--- a/tests/test_nirsevimab.py
+++ b/tests/test_nirsevimab.py
@@ -6,11 +6,7 @@ import pytest
 from dateutil.relativedelta import relativedelta
 from datetime import date
 
-from drugdemand import (
-    DrugDemand,
-    IndependentSubpopulations,
-    Population,
-)
+from drugdemand import DrugDemand, PopulationManager
 
 from drugdemand.nirsevimab import NirsevimabCalculator
 
@@ -90,14 +86,12 @@ def test_in_season():
     birth_date = datetime.date(2024, 11, 1)
     size = 100
     result = NirsevimabCalculator.calculate_demand(
-        Population(
-            size=size,
-            attributes={
-                "birth_date": birth_date,
-                "age_at_5kg": 1,
-                "will_receive": True,
-            },
-        ),
+        pop={
+            "birth_date": birth_date,
+            "age_at_5kg": 1,
+            "will_receive": True,
+        },
+        size=size,
         pars={
             "season_start": date(2024, 10, 1),
             "season_end": date(2025, 3, 31),
@@ -116,14 +110,12 @@ def test_after_season():
     birth_date = datetime.date(2025, 11, 1)
     size = 100
     result = NirsevimabCalculator.calculate_demand(
-        Population(
-            size=size,
-            attributes={
-                "birth_date": birth_date,
-                "age_at_5kg": 1,
-                "will_receive": True,
-            },
-        ),
+        size=size,
+        pop={
+            "birth_date": birth_date,
+            "age_at_5kg": 1,
+            "will_receive": True,
+        },
         pars={
             "season_start": date(2024, 10, 1),
             "season_end": date(2025, 3, 31),
@@ -143,14 +135,12 @@ def test_before_season():
     season_start = datetime.date(2024, 10, 1)
     size = 100
     result = NirsevimabCalculator.calculate_demand(
-        Population(
-            size=size,
-            attributes={
-                "birth_date": birth_date,
-                "age_at_5kg": 1,
-                "will_receive": True,
-            },
-        ),
+        size=size,
+        pop={
+            "birth_date": birth_date,
+            "age_at_5kg": 1,
+            "will_receive": True,
+        },
         pars={
             "season_start": date(2024, 10, 1),
             "season_end": date(2025, 3, 31),
@@ -174,15 +164,13 @@ def test_feb_2024():
     season_start = datetime.date(2024, 10, 1)
     size = 100
     result = NirsevimabCalculator.calculate_demand(
-        Population(
-            size=size,
-            attributes={
-                "birth_date": birth_date,
-                "age_at_5kg": 1,
-                "will_receive": True,
-                "risk_level": "high",
-            },
-        ),
+        size=size,
+        pop={
+            "birth_date": birth_date,
+            "age_at_5kg": 1,
+            "will_receive": True,
+            "risk_level": "high",
+        },
         pars={
             "season_start": season_start,
             "season_end": date(2025, 3, 31),
@@ -214,14 +202,12 @@ def test_simple_delay():
     birth_date = datetime.date(2024, 11, 1)
     size = 100
     result1 = NirsevimabCalculator.calculate_demand(
-        Population(
-            size=size,
-            attributes={
-                "birth_date": birth_date,
-                "age_at_5kg": 1,
-                "will_receive": True,
-            },
-        ),
+        size=size,
+        pop={
+            "birth_date": birth_date,
+            "age_at_5kg": 1,
+            "will_receive": True,
+        },
         pars={
             "season_start": date(2024, 10, 1),
             "season_end": date(2025, 3, 31),
@@ -232,15 +218,13 @@ def test_simple_delay():
     )
 
     result2 = NirsevimabCalculator.calculate_demand(
-        Population(
-            size=size,
-            attributes={
-                "birth_date": birth_date,
-                "age_at_5kg": 1,
-                "will_receive": True,
-                "delay": 1,
-            },
-        ),
+        size=size,
+        pop={
+            "birth_date": birth_date,
+            "age_at_5kg": 1,
+            "will_receive": True,
+            "delay": 1,
+        },
         pars={
             "season_start": date(2024, 10, 1),
             "season_end": date(2025, 3, 31),
@@ -259,15 +243,17 @@ def test_delay_props():
     birth_date = datetime.date(2024, 11, 1)
     size = 100
 
-    pop = Population(
+    pm = PopulationManager(
         size=size,
-        attributes={"birth_date": birth_date, "age_at_5kg": 1, "will_receive": True},
+        char_props={
+            "birth_date": {birth_date: 1.0},
+            "age_at_5kg": {1, 1.0},
+            "delay": {0: 0.8, 1: 0.2},
+        },
     )
 
-    subpops = IndependentSubpopulations(
-        pop, attribute_levels={"delay": {0: 0.8, 1: 0.2}}
-    )
-
+    # need to use map here
+    # probably want to allow for args and kwargs
     results = [
         NirsevimabCalculator.calculate_demand(
             subpop,

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -107,11 +107,8 @@ def test_pm_divide_twice():
         elif pop_dict["risk_level"] == "high":
             return {"characteristic": None, "value": 2.0 * size}
 
-        raise RuntimeError
-
-    print(pm.data)
-    print(list(pm.map(f_risk)))
-    print(pm.data)
+    # do the first partitions
+    list(pm.map(f_risk))
 
     def f_age(pop_dict, size):
         if pop_dict["age_group"] is None:
@@ -134,36 +131,3 @@ def test_pm_divide_twice():
         {"risk_level": "high", "age_group": "adult"},
         100 * 0.5 * 0.8,
     ) in results
-
-
-def test_independent():
-    """Check that populations can be arbitrarily sub-divided, and they are broken down
-    according to the correct proportions"""
-    subpops = IndependentSubpopulations(
-        Population(size=1.0),
-        attribute_levels={
-            "has_y_chromosome": {True: 0.5, False: 0.5},
-            "eye_color": {"brown": 0.5, "blue": 0.25, "green": 0.20, "other": 0.05},
-        },
-    )
-
-    pops = list(iter(subpops))
-
-    some_pop = Population(
-        size=1.0 * 0.5 * 0.5,
-        attributes={"eye_color": "brown", "has_y_chromosome": True},
-    )
-
-    assert some_pop in pops
-
-
-def test_subdivide_bad_proportions():
-    """Raise an error when attribute levels don't add up to 1"""
-    with pytest.raises(Exception):
-        list(
-            iter(
-                IndependentSubpopulations(
-                    Population(size=1.0), attribute_levels={"sex": {"m": 0.4, "f": 0.4}}
-                )
-            )
-        )

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,6 +1,139 @@
 import pytest
 
-from drugdemand import IndependentSubpopulations, Population
+from drugdemand import PopulationManager, CharacteristicProportions
+
+
+def test_char_prop_validate():
+    """Check that the validation of CharacteristicProportions works"""
+    # should fail on non-string keys
+    with pytest.raises(Exception):
+        CharacteristicProportions({1: {"baseline": 1.0}})
+
+    # should fail on non-dict values
+    with pytest.raises(Exception):
+        CharacteristicProportions({"baseline": 1})
+
+    # should fail on proportions that don't sum to 1
+    with pytest.raises(Exception):
+        CharacteristicProportions({"risk_level": {"low": 0.1, "high": 0.1}})
+
+    # should pass
+    CharacteristicProportions({"risk_level": {"low": 0.5, "high": 0.5}})
+
+    # two characteristics should pass
+    CharacteristicProportions(
+        {
+            "risk_level": {"low": 0.5, "high": 0.5},
+            "age_group": {"infant": 0.1, "child": 0.1, "adult": 0.8},
+        }
+    )
+
+
+def test_pm_init():
+    # should get initial population with all None ID
+    pm = PopulationManager(
+        100,
+        CharacteristicProportions(
+            {
+                "risk_level": {"low": 0.5, "high": 0.5},
+                "age_group": {"infant": 0.1, "child": 0.1, "adult": 0.8},
+            }
+        ),
+    )
+
+    assert pm.data == {(None, None): 100}
+
+
+def test_update_tuple():
+    x = (1, 2, 3)
+    assert PopulationManager.update_tuple(x, 1, "foo") == (1, "foo", 3)
+
+    with pytest.raises(Exception):
+        PopulationManager.update_tuple(x, 3, "foo")
+
+    with pytest.raises(Exception):
+        PopulationManager.update_tuple(x, -1, "foo")
+
+
+def test_pm_divide1():
+    pm = PopulationManager(
+        100,
+        CharacteristicProportions(
+            {
+                "risk_level": {"low": 0.5, "high": 0.5},
+                "age_group": {"infant": 0.1, "child": 0.1, "adult": 0.8},
+            }
+        ),
+    )
+
+    def f(pop_dict, size):
+        if pop_dict["risk_level"] is None:
+            return {"characteristic": "risk_level", "value": None}
+        elif pop_dict["risk_level"] == "low":
+            return {"characteristic": None, "value": 0.1 * size}
+        elif pop_dict["risk_level"] == "high":
+            return {"characteristic": None, "value": 2.0 * size}
+
+    results = list(pm.map(f))
+
+    assert len(results) == 2
+
+    assert ({"risk_level": "low", "age_group": None}, 100 * 0.5 * 0.1) in results
+    assert ({"risk_level": "high", "age_group": None}, 100 * 0.5 * 2.0) in results
+
+    assert pm.get_size({"risk_level": "low", "age_group": None}) == 100 * 0.5
+    assert pm.get_size({"risk_level": "high", "age_group": None}) == 100 * 0.5
+
+
+def test_pm_divide_twice():
+    pm = PopulationManager(
+        100,
+        CharacteristicProportions(
+            {
+                "risk_level": {"low": 0.5, "high": 0.5},
+                "age_group": {"infant": 0.1, "child": 0.1, "adult": 0.8},
+            }
+        ),
+    )
+
+    def f_risk(pop_dict, size):
+        if size == 0:
+            return {"characteristic": None, "value": 0}
+
+        if pop_dict["risk_level"] is None:
+            return {"characteristic": "risk_level", "value": None}
+        elif pop_dict["risk_level"] == "low":
+            return {"characteristic": None, "value": 0.1 * size}
+        elif pop_dict["risk_level"] == "high":
+            return {"characteristic": None, "value": 2.0 * size}
+
+        raise RuntimeError
+
+    print(pm.data)
+    print(list(pm.map(f_risk)))
+    print(pm.data)
+
+    def f_age(pop_dict, size):
+        if pop_dict["age_group"] is None:
+            return {"characteristic": "age_group", "value": None}
+        elif pop_dict["age_group"] == "infant":
+            return {"characteristic": None, "value": 0}
+        elif pop_dict["age_group"] == "child":
+            return {"characteristic": None, "value": 0}
+        elif pop_dict["age_group"] == "adult":
+            return {"characteristic": None, "value": size}
+
+    results = list(pm.map(f_age))
+
+    assert len(results) == 6
+    assert (
+        {"risk_level": "low", "age_group": "adult"},
+        100 * 0.5 * 0.8,
+    ) in results
+    assert (
+        {"risk_level": "high", "age_group": "adult"},
+        100 * 0.5 * 0.8,
+    ) in results
 
 
 def test_independent():

--- a/tests/test_population_id.py
+++ b/tests/test_population_id.py
@@ -1,0 +1,63 @@
+import pytest
+from drugdemand import (
+    PopulationID,
+    UnresolvedCharacteristic,
+    UnresolvedCharacteristicException,
+)
+
+
+def test_popid_init():
+    PopulationID({"age": "adult", "sex": UnresolvedCharacteristic()})
+
+
+def test_popid_from_chars():
+    pop = PopulationID.from_characteristics(["age", "sex"])
+    assert pop.mapping == {
+        "age": UnresolvedCharacteristic(),
+        "sex": UnresolvedCharacteristic(),
+    }
+
+
+def test_popid_basic_patterns():
+    pop = PopulationID({"age": "adult", "sex": UnresolvedCharacteristic()})
+    # can get values
+    assert pop["age"] == "adult"
+    # can get values with defaults
+    assert pop.get("foo", None) is None
+    # can get length
+    assert len(pop) == 2
+
+
+def test_raise_unresolved():
+    pop = PopulationID(
+        {"age": "adult", "sex": UnresolvedCharacteristic()}, raise_if_unresolved=True
+    )
+    with pytest.raises(UnresolvedCharacteristicException) as exc_info:
+        pop["sex"]
+
+    # pytest gives you an ExceptionInfo objects; pull out the exception itself
+    e = exc_info.value
+    assert e.args[0] == "sex"
+
+
+def test_cycle_raise_unresolved():
+    pop = PopulationID({"age": "adult", "sex": UnresolvedCharacteristic()})
+
+    # raise no error
+    pop["sex"]
+
+    # now raise an error
+    pop.raise_if_unresolved = True
+
+    with pytest.raises(UnresolvedCharacteristicException):
+        pop["sex"]
+
+    # and reverse
+    pop.raise_if_unresolved = False
+    pop["sex"]
+
+
+def test_can_union():
+    pop = PopulationID({"age": "adult"})
+    new_pop = pop | {"sex": "male"}
+    assert isinstance(new_pop, PopulationID)


### PR DESCRIPTION
# Original idea

Populations, defined by a dictionary `{characteristic: level}`, are managed through a `PopulationManager`, that keeps track of their sizes. Initially, all of those levels are `UnresolvedCharacteristic`, i.e., unpartitioned.

The eligibility/demand function takes a `PopulationID`, a sort of immutable dictionary, and a size. It returns an output of any type (e.g., `DrugDemand`). If the demand function queries a characteristic of the population ID that is not resolved, an exception is raised that causes the population manager to partition the population on that characteristic.

Resolves #20 

# Problems

## Use of exceptions

We should *not* use an exception here, to trigger on unresolved characteristics. Exceptions are for truly breaking errors in code, whereas unresolved characteristics are an expected and routine feature.

## Conflating query and mutate functionality

`PopulationManager.map()` is both querying (i.e., clarifying which people are going to produce demand on which days) and mutating (i.e., partitioning populations). This makes it a dynamic and confusing system.

To make this clearer, we should be running the two operations separately: one to divide populations, and one to compute demand.

Ultimately the approach here will be superseded either by something like an agent-based approach (which would be more straightforward, mechanistically) or an approach that can invert the eligibility function (to say: what people will demand 2x100 mg doses in Oct 2024 week 2?). The whole simulation runs in a few seconds so there is no need for this kind of optimization.