### PR TITLE
Use a special "unresolved characteristic" type

### DIFF
--- a/drugdemand/__init__.py
+++ b/drugdemand/__init__.py
@@ -49,15 +49,16 @@ class CharacteristicProportions(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.validate()
+        self.validate(self)
 
-    def validate(self):
+    @staticmethod
+    def validate(x):
         # all keys (characteristics) should be strings
-        assert all(isinstance(k, str) for k in self.keys())
+        assert all(isinstance(k, str) for k in x.keys())
         # all values (proportions) should be dictionaries
-        assert all(isinstance(v, dict) for v in self.values())
+        assert all(isinstance(v, dict) for v in x.values())
         # all proportions of a characteristic should sum to 1
-        for char, props in self.items():
+        for char, props in x.items():
             assert np.isclose(sum(props.values()), 1.0)
 
 

--- a/drugdemand/__init__.py
+++ b/drugdemand/__init__.py
@@ -90,7 +90,7 @@ class UnresolvedCharacteristic:
         return isinstance(other, UnresolvedCharacteristic)
 
     def __hash__(self):
-        return hash("UnresolveCharacteristic")
+        return hash("UnresolvedCharacteristic")
 
 
 class PopulationManager:

--- a/drugdemand/__init__.py
+++ b/drugdemand/__init__.py
@@ -93,6 +93,9 @@ class UnresolvedCharacteristic:
     def __hash__(self):
         return hash("UnresolvedCharacteristic")
 
+    def __str__(self):
+        return "unresolved"
+
 
 class PopulationManager:
     def __init__(self, size: float, char_props: CharacteristicProportions):

--- a/drugdemand/nirsevimab.py
+++ b/drugdemand/nirsevimab.py
@@ -103,6 +103,10 @@ class NirsevimabCalculator:
         # parameter validity checks
         assert "interval" in pars
 
+        # zero-size populations get nothing
+        if size == 0:
+            return PopulationResult(value=None)
+
         # if population will not uptake, stop right away
         if isinstance(pop["will_receive"], UnresolvedCharacteristic):
             return PopulationResult(char_to_resolve="will_receive")

--- a/drugdemand/nirsevimab.py
+++ b/drugdemand/nirsevimab.py
@@ -78,7 +78,7 @@ class NirsevimabCalculator:
 
     @classmethod
     def calculate_demand(
-        cls, pop: dict[str, str], size: float, pars: dict
+        cls, pop: PopulationID, size: float, pars: dict
     ) -> DrugDemand | None:
         """Calculate amount and timing of demand, for a single population
 

--- a/tests/test_nirsevimab.py
+++ b/tests/test_nirsevimab.py
@@ -10,7 +10,6 @@ from drugdemand import (
     DrugDemand,
     PopulationManager,
     CharacteristicProportions,
-    PopulationResult,
     UnresolvedCharacteristic,
 )
 
@@ -88,6 +87,9 @@ def test_all():
     # that demand is the same by date and by birth cohort
     common_groups = ["season_start", "interval", "drug_dosage", "uptake", "p_high_risk"]
 
+    assert set(common_groups).issubset(expected_results.columns)
+    assert set(common_groups).issubset(results.columns)
+
     expected_by_birth = expected_results.group_by(common_groups + ["birth_date"]).agg(
         pl.col("n_doses").sum()
     )
@@ -137,7 +139,7 @@ def test_in_season():
         },
     )
 
-    assert result == PopulationResult(value=DrugDemand("50mg", size, birth_date))
+    assert result == DrugDemand("50mg", size, birth_date)
 
 
 def test_after_season():
@@ -161,7 +163,7 @@ def test_after_season():
         },
     )
 
-    assert result == PopulationResult(value=None)
+    assert result is None
 
 
 def test_before_season():
@@ -187,7 +189,7 @@ def test_before_season():
         },
     )
 
-    assert result == PopulationResult(value=DrugDemand("100mg", size, season_start))
+    assert result == DrugDemand("100mg", size, season_start)
 
 
 def test_feb_2024():
@@ -216,7 +218,7 @@ def test_feb_2024():
         },
     )
 
-    assert result == PopulationResult(value=DrugDemand("100mg", size * 2, season_start))
+    assert result == DrugDemand("100mg", size * 2, season_start)
 
 
 def test_parse_delay():
@@ -264,7 +266,7 @@ def test_simple_delay():
         pars=pars,
     )
 
-    assert result2.value.time == result1.value.time + relativedelta(months=1)
+    assert result2.time == result1.time + relativedelta(months=1)
 
 
 def test_delay_props():

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,6 +1,6 @@
 import pytest
 
-from drugdemand import PopulationManager, CharacteristicProportions
+from drugdemand import PopulationResult, PopulationManager, CharacteristicProportions
 
 
 def test_char_prop_validate():
@@ -44,17 +44,6 @@ def test_pm_init():
     assert pm.data == {(None, None): 100}
 
 
-def test_update_tuple():
-    x = (1, 2, 3)
-    assert PopulationManager.update_tuple(x, 1, "foo") == (1, "foo", 3)
-
-    with pytest.raises(Exception):
-        PopulationManager.update_tuple(x, 3, "foo")
-
-    with pytest.raises(Exception):
-        PopulationManager.update_tuple(x, -1, "foo")
-
-
 def test_pm_divide1():
     pm = PopulationManager(
         100,
@@ -68,11 +57,11 @@ def test_pm_divide1():
 
     def f(pop_dict, size):
         if pop_dict["risk_level"] is None:
-            return {"characteristic": "risk_level", "value": None}
+            return PopulationResult(char_to_resolve="risk_level")
         elif pop_dict["risk_level"] == "low":
-            return {"characteristic": None, "value": 0.1 * size}
+            return PopulationResult(value=0.1 * size)
         elif pop_dict["risk_level"] == "high":
-            return {"characteristic": None, "value": 2.0 * size}
+            return PopulationResult(value=2.0 * size)
 
     results = list(pm.map(f))
 
@@ -98,27 +87,27 @@ def test_pm_divide_twice():
 
     def f_risk(pop_dict, size):
         if size == 0:
-            return {"characteristic": None, "value": 0}
+            return PopulationResult(value=0)
 
         if pop_dict["risk_level"] is None:
-            return {"characteristic": "risk_level", "value": None}
+            return PopulationResult(char_to_resolve="risk_level")
         elif pop_dict["risk_level"] == "low":
-            return {"characteristic": None, "value": 0.1 * size}
+            return PopulationResult(value=0.1 * size)
         elif pop_dict["risk_level"] == "high":
-            return {"characteristic": None, "value": 2.0 * size}
+            return PopulationResult(value=2.0 * size)
 
     # do the first partitions
     list(pm.map(f_risk))
 
     def f_age(pop_dict, size):
         if pop_dict["age_group"] is None:
-            return {"characteristic": "age_group", "value": None}
+            return PopulationResult(char_to_resolve="age_group")
         elif pop_dict["age_group"] == "infant":
-            return {"characteristic": None, "value": 0}
+            return PopulationResult(value=0)
         elif pop_dict["age_group"] == "child":
-            return {"characteristic": None, "value": 0}
+            return PopulationResult(value=0)
         elif pop_dict["age_group"] == "adult":
-            return {"characteristic": None, "value": size}
+            return PopulationResult(value=size)
 
     results = list(pm.map(f_age))
 

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,9 +1,9 @@
 import pytest
 
 from drugdemand import (
-    PopulationResult,
     PopulationManager,
     CharacteristicProportions,
+    PopulationID,
     UnresolvedCharacteristic,
 )
 
@@ -49,6 +49,25 @@ def test_pm_init():
     assert pm.data == {(UnresolvedCharacteristic(), UnresolvedCharacteristic()): 100}
 
 
+def test_pm_partition():
+    pm = PopulationManager(
+        100,
+        CharacteristicProportions(
+            {
+                "risk_level": {"low": 0.5, "high": 0.5},
+                "age_group": {"infant": 0.1, "child": 0.1, "adult": 0.8},
+            }
+        ),
+    )
+
+    pops = list(pm.pops())
+    assert len(pops) == 1
+    pop = pops[0]
+    pm.partition(pop, "risk_level")
+
+    assert pm.get_size(PopulationID({"risk_level": "low"})) == 50
+
+
 def test_pm_divide1():
     pm = PopulationManager(
         100,
@@ -60,13 +79,13 @@ def test_pm_divide1():
         ),
     )
 
-    def f(pop_dict, size):
-        if isinstance(pop_dict["risk_level"], UnresolvedCharacteristic):
-            return PopulationResult(char_to_resolve="risk_level")
-        elif pop_dict["risk_level"] == "low":
-            return PopulationResult(value=0.1 * size)
-        elif pop_dict["risk_level"] == "high":
-            return PopulationResult(value=2.0 * size)
+    def f(pop, size):
+        if pop["risk_level"] == "low":
+            return 0.1 * size
+        elif pop["risk_level"] == "high":
+            return 2.0 * size
+        else:
+            raise RuntimeError
 
     results = list(pm.map(f))
 
@@ -104,31 +123,22 @@ def test_pm_divide_twice():
 
     def f_risk(pop_dict, size):
         if size == 0:
-            return PopulationResult(value=0)
-        elif isinstance(pop_dict["risk_level"], UnresolvedCharacteristic):
-            return PopulationResult(char_to_resolve="risk_level")
+            return 0
         elif pop_dict["risk_level"] == "low":
-            return PopulationResult(value=0.1 * size)
+            return 0.1 * size
         elif pop_dict["risk_level"] == "high":
-            return PopulationResult(value=2.0 * size)
+            return 2.0 * size
         else:
-            print(pop_dict["risk_level"])
-            print(type(pop_dict["risk_level"]))
-            print(isinstance(pop_dict["risk_level"], UnresolvedCharacteristic))
             raise RuntimeError
 
     # do the first partitions
     list(pm.map(f_risk))
 
     def f_age(pop_dict, size):
-        if isinstance(pop_dict["age_group"], UnresolvedCharacteristic):
-            return PopulationResult(char_to_resolve="age_group")
-        elif pop_dict["age_group"] == "infant":
-            return PopulationResult(value=0)
-        elif pop_dict["age_group"] == "child":
-            return PopulationResult(value=0)
+        if pop_dict["age_group"] in ["infant", "child"]:
+            return 0
         elif pop_dict["age_group"] == "adult":
-            return PopulationResult(value=size)
+            return size
         else:
             raise RuntimeError
 
@@ -151,12 +161,10 @@ def test_pm_takes_args():
     )
 
     def f(pop, size, multiplier):
-        if isinstance(pop["risk_level"], UnresolvedCharacteristic):
-            return PopulationResult(char_to_resolve="risk_level")
-        elif pop["risk_level"] == "low":
-            return PopulationResult(value=0.1 * size * multiplier)
+        if pop["risk_level"] == "low":
+            return 0.1 * size * multiplier
         elif pop["risk_level"] == "high":
-            return PopulationResult(value=2.0 * size * multiplier)
+            return 2.0 * size * multiplier
         else:
             raise RuntimeError
 
@@ -175,12 +183,10 @@ def test_pm_takes_kwargs():
     )
 
     def f(pop, size, multiplier):
-        if isinstance(pop["risk_level"], UnresolvedCharacteristic):
-            return PopulationResult(char_to_resolve="risk_level")
-        elif pop["risk_level"] == "low":
-            return PopulationResult(value=0.1 * size * multiplier)
+        if pop["risk_level"] == "low":
+            return 0.1 * size * multiplier
         elif pop["risk_level"] == "high":
-            return PopulationResult(value=2.0 * size * multiplier)
+            return 2.0 * size * multiplier
         else:
             raise RuntimeError
 

--- a/tests/test_population_id.py
+++ b/tests/test_population_id.py
@@ -1,0 +1,63 @@
+import pytest
+from drugdemand import (
+    PopulationID,
+    UnresolvedCharacteristic,
+    UnresolvedCharacteristicException,
+)
+
+
+def test_popid_init():
+    PopulationID({"age": "adult", "sex": UnresolvedCharacteristic()})
+
+
+def test_popid_from_chars():
+    pop = PopulationID.from_characteristics(["age", "sex"])
+    assert pop.mapping == {
+        "age": UnresolvedCharacteristic(),
+        "sex": UnresolvedCharacteristic(),
+    }
+
+
+def test_popid_basic_patterns():
+    pop = PopulationID({"age": "adult", "sex": UnresolvedCharacteristic()})
+    # can get values
+    assert pop["age"] == "adult"
+    # can get values with defaults
+    assert pop.get("foo", None) is None
+    # can get length
+    assert len(pop) == 2
+
+
+def test_raise_unresolved():
+    pop = PopulationID(
+        {"age": "adult", "sex": UnresolvedCharacteristic()}, raise_if_unresolved=True
+    )
+    with pytest.raises(UnresolvedCharacteristicException) as exc_info:
+        pop["sex"]
+
+    # pytest gives you an ExceptionInfo objects; pull out the exception itself
+    e = exc_info.value
+    assert e.args[0] == "sex"
+
+
+def test_cycle_raise_unresolved():
+    pop = PopulationID({"age": "adult", "sex": UnresolvedCharacteristic()})
+
+    # raise no error
+    pop["sex"]
+
+    # now raise an error
+    pop.raise_if_unresolved = True
+
+    with pytest.raises(UnresolvedCharacteristicException):
+        pop["sex"]
+
+    # and reverse
+    pop.raise_if_unresolved = False
+    pop["sex"]
+
+
+def test_can_union():
+    pop = PopulationID({"age": "adult"})
+    new_pop = pop | {"sex": "male"}
+    assert isinstance(new_pop, PopulationID)


### PR DESCRIPTION
In #21, I had set up a population ID such that `{characteristic: None}` indicated that that characteristic was unresolved. This is ambiguous because you might have a characteristic that you really want to be `None`. So instead I cooked up a new object class `UnresolvedCharacteristic`.

`PopulationManager.map(f)` will raise an exception if the function `f` looks for an unresolved characteristic in any `PopulationID`, resolve that characteristic, and manage the stack of populations to be mapped over.

See #24, which was merged into this one, for more information